### PR TITLE
Fix fo '.' missing from @INC in perl 5.26+ RT#120808

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Digest::BubbleBabble
 
+    - Fix Makefile.PL being broken due to '.' removal from default @INC
+      since Perl 5.25.11 ( RT#120808 )
+
 0.02  2011.03.23
     - Fixed a bug affecting input strings with an odd number of
       characters. Thanks to Ken T Takusagawa for the report.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 name 'Digest-BubbleBabble';
 all_from 'lib/Digest/BubbleBabble.pm';


### PR DESCRIPTION
Tested, works-for-me and passes tests with PERL_USE_UNSAFE_INC=0 set in environment.

Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=120808
